### PR TITLE
Create shrine-dynamoid first implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+Gemfile.lock
+pkg/
+.byebug_history

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,49 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting a project maintainer at janko.marohnic@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. Maintainers are
+obligated to maintain confidentiality with regard to the reporter of an
+incident.
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem "pry"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Janko Marohnić
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,192 @@
+# Shrine::Plugins::Dynamoid
+
+Provides [Dynamoid] integration for [Shrine].
+
+## Installation
+
+```ruby
+gem "shrine-dynamoid", "~> 0.1"
+```
+
+## Usage
+
+```rb
+Shrine.plugin :dynamoid
+```
+```rb
+class ImageUploader < Shrine
+end
+```
+```rb
+class Photo
+  include Dynamoid::Document
+  include ImageUploader::Attachment(:image)
+
+  field :image_data, :string # or `:raw`
+end
+```
+
+The `Shrine::Attachment` module will add [model] methods, as well as
+[callbacks](#callbacks) and [validations](#validations) to tie attachment
+process to the record lifecycle:
+
+```rb
+photo = Photo.new
+
+photo.image = file # cache attachment
+
+photo.image      #=> #<Shrine::UploadedFile @id="bc2e13.jpg" @storage_key=:cache ...>
+photo.image_data #=> '{"id":"bc2e13.jpg","storage":"cache","metadata":{...}}'
+
+photo.save # persist, promote attachment, then persist again
+
+photo.image      #=> #<Shrine::UploadedFile @id="397eca.jpg" @storage_key=:store ...>
+photo.image_data #=> '{"id":"397eca.jpg","storage":"store","metadata":{...}}'
+
+photo.destroy # delete attachment
+
+photo.image.exists? #=> false
+```
+
+### Callbacks
+
+#### After Save
+
+After a record is saved, `Attacher#finalize` is called, which promotes cached
+file to permanent storage and deletes previous file if any.
+
+```rb
+photo = Photo.new
+
+photo.image = file
+photo.image.storage_key #=> :cache
+
+photo.save
+photo.image.storage_key #=> :store
+```
+
+#### After Destroy
+
+After a record is destroyed, `Attacher#destroy_attached` method is called,
+which deletes stored attached file if any.
+
+```rb
+photo = Photo.find(photo_id)
+photo.image #=> #<Shrine::UploadedFile>
+photo.image.exists? #=> true
+
+photo.destroy
+photo.image.exists? #=> false
+```
+
+#### Skipping Callbacks
+
+If you don't want the attachment module to add any callbacks to your model, you
+can set `:callbacks` to `false`:
+
+```rb
+plugin :dynamoid, callbacks: false
+```
+
+### Validations
+
+If you're using the [`validation`][validation] plugin, the attachment module
+will automatically merge attacher errors with model errors.
+
+```rb
+class ImageUploader < Shrine
+  plugin :validation_helpers
+
+  Attacher.validate do
+    validate_max_size 10 * 1024 * 1024
+  end
+end
+```
+```rb
+photo = Photo.new
+photo.image = file
+photo.valid?
+photo.errors #=> { image: ["size must not be greater than 10.0 MB"] }
+```
+
+#### Attachment Presence
+
+If you want to validate presence of the attachment, you can use ActiveModel's
+presence validator:
+
+```rb
+class Photo
+  include Dynamoid::Document
+  include ImageUploader::Attachment(:image)
+
+  validates_presence_of :image
+end
+```
+
+#### Skipping Validations
+
+If you don't want the attachment module to merge file validations errors into
+model errors, you can set `:validations` to `false`:
+
+```rb
+plugin :dynamoid, validations: false
+```
+
+## Attacher
+
+You can also use `Shrine::Attacher` directly (with or without the
+`Shrine::Attachment` module):
+
+```rb
+class Photo
+  include Dynamoid::Document
+
+  field :image_data, :string # or `:raw`
+end
+```
+```rb
+photo    = Photo.new
+attacher = ImageUploader::Attacher.from_model(photo, :image)
+
+attacher.assign(file) # cache
+
+attacher.file    #=> #<Shrine::UploadedFile @id="bc2e13.jpg" @storage_key=:cache ...>
+photo.image_data #=> '{"id":"bc2e13.jpg","storage":"cache","metadata":{...}}'
+
+photo.save        # persist
+attacher.finalize # promote
+photo.save        # persist
+
+attacher.file    #=> #<Shrine::UploadedFile @id="397eca.jpg" @storage_key=:store ...>
+photo.image_data #=> '{"id":"397eca.jpg","storage":"store","metadata":{...}}'
+```
+
+### Pesistence
+
+The following persistence methods are added to `Shrine::Attacher`:
+
+| Method                    | Description                                                            |
+| :-----                    | :----------                                                            |
+| `Attacher#atomic_promote` | calls `Attacher#promote` and persists if the attachment hasn't changed |
+| `Attacher#atomic_persist` | saves changes if the attachment hasn't changed                         |
+| `Attacher#persist`        | saves any changes to the underlying record                             |
+
+See [persistence] docs for more details.
+
+## Contributing
+
+You can run the tests with the Rake task:
+
+```
+$ bundle exec rake test
+```
+
+## License
+
+[MIT](LICENSE.txt)
+
+[Dynamoid]: https://github.com/Dynamoid/dynamoid
+[Shrine]: https://github.com/shrinerb/shrine
+[model]: https://github.com/shrinerb/shrine/blob/master/doc/plugins/model.md#readme
+[validation]: https://github.com/shrinerb/shrine/blob/master/doc/plugins/validation.md#readme
+[persistence]: https://github.com/shrinerb/shrine/blob/master/doc/plugins/persistence.md#readme

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList["test/**/*_test.rb"]
+  t.warning = false
+end
+
+task :default => :test

--- a/lib/shrine/plugins/dynamoid.rb
+++ b/lib/shrine/plugins/dynamoid.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "dynamoid"
+
+class Shrine
+  module Plugins
+    module Dynamoid
+      def self.load_dependencies(uploader, *)
+        uploader.plugin :model
+        uploader.plugin :_persistence, plugin: self
+      end
+
+      def self.configure(uploader, **opts)
+        uploader.opts[:dynamoid] ||= { validations: true, callbacks: true }
+        uploader.opts[:dynamoid].merge!(opts)
+      end
+
+      module AttachmentMethods
+        def included(model)
+          super
+
+          return unless model < ::Dynamoid::Document
+
+          name = @name
+
+          if shrine_class.opts[:dynamoid][:validations]
+            # add validation plugin integration
+            model.validate do
+              next unless send(:"#{name}_attacher").respond_to?(:errors)
+
+              send(:"#{name}_attacher").errors.each do |message|
+                errors.add(name, message)
+              end
+            end
+          end
+
+          if shrine_class.opts[:dynamoid][:callbacks]
+            model.before_save do
+              if send(:"#{name}_attacher").changed?
+                send(:"#{name}_attacher").save
+              end
+            end
+
+            model.after_save do
+              if send(:"#{name}_attacher").changed?
+                send(:"#{name}_attacher").finalize
+                send(:"#{name}_attacher").persist
+              end
+            end
+
+            model.after_destroy do
+              send(:"#{name}_attacher").destroy_attached
+            end
+          end
+
+          define_method :reload do |*args|
+            result = super(*args)
+            instance_variable_set(:"@#{name}_attacher", nil)
+            result
+          end
+        end
+      end
+
+      # The _persistence plugin uses #dynamoid_persist, #dynamoid_reload and
+      # #dynamoid? to implement the following methods:
+      #
+      #   * Attacher#persist
+      #   * Attacher#atomic_persist
+      #   * Attacher#atomic_promote
+      module AttacherMethods
+        private
+
+        # Saves changes to the model instance, raising exception on validation
+        # errors. Used by the _persistence plugin.
+        def dynamoid_persist
+          record.save(validate: false)
+        end
+
+        # Yields the reloaded record. Used by the _persistence plugin.
+        def dynamoid_reload
+          record_copy    = record.dup
+          record_copy.id = record.id
+
+          yield record_copy.reload
+        end
+
+        # Returns true if the data attribute represents a :raw field.
+        # However this is not certain as :raw fields can store different types
+        # of data. Used by the _persistence plugin to determine whether
+        # serialization should be skipped.
+        def dynamoid_hash_attribute?
+          field = record.class.attributes[attribute]
+          field && field[:type] == :raw
+        end
+
+        # Returns whether the record is a Dynamoid document. Used by the
+        # _persistence plugin.
+        def dynamoid?
+          record.is_a?(::Dynamoid::Document)
+        end
+      end
+    end
+
+    register_plugin(:dynamoid, Dynamoid)
+  end
+end

--- a/shrine-dynamoid.gemspec
+++ b/shrine-dynamoid.gemspec
@@ -1,0 +1,23 @@
+Gem::Specification.new do |gem|
+  gem.name          = "shrine-dynamoid"
+  gem.version       = "0.1.0"
+
+  gem.required_ruby_version = ">= 2.3"
+
+  gem.summary      = "Provides Dynamoid integration for Shrine."
+  gem.homepage     = "https://github.com/shrinerb/shrine-dynamoid"
+  gem.authors      = ["Janko Marohnić", "Patryk Kotarski"]
+  gem.email        = ["patrykkotarski21@gmail.com"]
+  gem.license      = "MIT"
+
+  gem.files        = Dir["README.md", "LICENSE.txt", "lib/**/*.rb", "*.gemspec"]
+  gem.require_path = "lib"
+
+  gem.add_dependency "shrine", ">= 3.0.0.beta2", "< 4"
+  gem.add_dependency "dynamoid", ">= 2.2"
+
+  gem.add_development_dependency "rake"
+  gem.add_development_dependency "minitest"
+  gem.add_development_dependency "mocha"
+  gem.add_development_dependency "minitest-byebug"
+end

--- a/test/dynamoid.yml
+++ b/test/dynamoid.yml
@@ -1,0 +1,3 @@
+test:
+  database: shrine_dynamoid_test
+  host: http://localhost:8000

--- a/test/dynamoid_test.rb
+++ b/test/dynamoid_test.rb
@@ -1,0 +1,565 @@
+require_relative "test_helper"
+require "shrine/plugins/dynamoid"
+
+describe Shrine::Plugins::Dynamoid do
+  let(:user_class) do
+    user_class = Class.new
+    user_class.include Dynamoid::Document
+    user_class.table name: :users, key: :id
+    user_class.field :id, :string
+    user_class.field :name, :string
+    user_class.field :avatar_data, :string
+
+    # Dynamoid doesn't have an API for `update_all` but makes tests clearer
+    user_class.send(:define_singleton_method, :update_all) do |attributes|
+      user_class.all.each do |user|
+        user.update_attributes(attributes)
+      end
+    end
+
+    user_class
+  end
+
+  before do
+    Dynamoid::Reset.all
+
+    @shrine = Class.new(Shrine)
+    @shrine.storages[:cache] = Shrine::Storage::Memory.new
+    @shrine.storages[:store] = Shrine::Storage::Memory.new
+
+    @shrine.plugin :dynamoid
+
+    @user     = user_class.new
+    @attacher = @shrine::Attacher.from_model(@user, :avatar)
+  end
+
+  describe "Attachment" do
+    describe "validate" do
+      before do
+        @shrine.plugin :validation
+      end
+
+      it "adds attacher errors to the record" do
+        @user.class.include @shrine::Attachment.new(:avatar)
+
+        @attacher.class.validate { errors << "error" }
+        @user.avatar = fakeio
+        refute @user.valid?
+        assert_equal Hash[avatar: ["error"]], @user.errors.to_hash
+      end
+
+      it "is skipped if validations are disabled" do
+        @shrine.plugin :dynamoid, validations: false
+        @user.class.include @shrine::Attachment.new(:avatar)
+
+        @attacher.class.validate { errors << "error" }
+        @user.avatar = fakeio
+        assert @user.valid?
+      end
+    end
+
+    describe "before_save" do
+      it "calls Attacher#save if attachment has changed" do
+        @user.class.include @shrine::Attachment.new(:avatar)
+
+        @user.avatar = fakeio
+        @user.avatar_attacher.expects(:save).once
+        @user.save
+      end
+
+      it "doesn't call Attacher#save if attachment has not changed" do
+        @user.class.include @shrine::Attachment.new(:avatar)
+
+        @user.name = "Janko"
+        @user.avatar_attacher.expects(:save).never
+        @user.save
+      end
+
+      it "is skipped when callbacks are disabled" do
+        @shrine.plugin :dynamoid, callbacks: false
+        @user.class.include @shrine::Attachment.new(:avatar)
+
+        @user.avatar = fakeio
+        @user.avatar_attacher.expects(:save).never
+        @user.save
+      end
+    end
+
+    describe "after_save" do
+      it "finalizes attacher when attachment changes" do
+        @user.class.include @shrine::Attachment.new(:avatar)
+
+        previous_file = @attacher.upload(fakeio)
+        @user.avatar_data = previous_file.to_json
+
+        @user.avatar = fakeio
+        @user.save
+
+        assert_equal :store, @user.avatar.storage_key
+        refute previous_file.exists?
+      end
+
+      it "persists changes after finalization" do
+        @user.class.include @shrine::Attachment.new(:avatar)
+
+        @user.avatar = fakeio
+        @user.save
+        @user.reload
+
+        assert_equal :store, @user.avatar.storage_key
+      end
+
+      it "ignores validation errors" do
+        @user.class.include @shrine::Attachment.new(:avatar)
+        @user.class.validate do
+          errors.add(:name, "must be present")
+        end
+
+        @user.avatar = fakeio
+        @user.save(validate: false)
+        @user.reload
+
+        assert_equal :store, @user.avatar.storage_key
+      end
+
+      it "is skipped when callbacks are disabled" do
+        @shrine.plugin :dynamoid, callbacks: false
+        @user.class.include @shrine::Attachment.new(:avatar)
+
+        @user.avatar = fakeio
+        @user.save
+
+        assert_equal :cache, @user.avatar.storage_key
+      end
+    end
+
+    describe "after_destroy" do
+      it "deletes attached files" do
+        @user.class.include @shrine::Attachment.new(:avatar)
+
+        @attacher.attach(fakeio)
+        @user.save
+
+        @user.destroy
+
+        refute @user.avatar.exists?
+      end
+
+      it "is skipped when callbacks are disabled" do
+        @shrine.plugin :dynamoid, callbacks: false
+        @user.class.include @shrine::Attachment.new(:avatar)
+
+        @attacher.attach(fakeio)
+        @user.save
+
+        @user.destroy
+
+        assert @user.avatar.exists?
+      end
+    end
+
+    describe "#reload" do
+      it "reloads the attacher" do
+        @user.class.include @shrine::Attachment.new(:avatar)
+
+        @user.save
+        @user.avatar_attacher # ensure attacher is memoized
+
+        file = @attacher.upload(fakeio)
+        @user.class.update_all(avatar_data: file.to_json)
+
+        @user.reload
+
+        assert_equal file, @user.avatar
+      end
+
+      it "returns self" do
+        @user.class.include @shrine::Attachment.new(:avatar)
+
+        @user.save
+
+        assert_equal @user, @user.reload
+      end
+    end
+
+    it "can still be included into non-Dynamoid classes" do
+      model_class = Struct.new(:image_data)
+      model_class.include @shrine::Attachment.new(:avatar)
+    end
+  end
+
+  describe "Attacher" do
+    describe "JSON columns" do
+      after do
+        @user.class.field :avatar_data, :string
+      end
+
+      it "handles Hash type" do
+        @user.class.field :avatar_data, :raw
+
+        @attacher.load_model(@user, :avatar)
+        @attacher.attach(fakeio)
+
+        assert_equal @attacher.file.data, @user.avatar_data
+
+        @attacher.reload
+
+        assert_equal @attacher.file.data, @user.avatar_data
+      end
+    end
+
+    describe "#atomic_promote" do
+      it "promotes cached file to permanent storage" do
+        @attacher.attach_cached(fakeio)
+        @user.save
+
+        @attacher.atomic_promote
+
+        assert @attacher.stored?
+        @attacher.reload
+        assert @attacher.stored?
+      end
+
+      it "updates the record with promoted file" do
+        @attacher.attach_cached(fakeio)
+        @user.save
+
+        @attacher.atomic_promote
+
+        @user.reload
+        @attacher.reload
+        assert @attacher.stored?
+      end
+
+      it "returns the promoted file" do
+        @attacher.attach_cached(fakeio)
+        @user.save
+
+        file = @attacher.atomic_promote
+
+        assert_equal @attacher.file, file
+      end
+
+      it "accepts promote options" do
+        @attacher.attach_cached(fakeio)
+        @user.save
+
+        @attacher.atomic_promote(location: "foo")
+
+        assert_equal "foo", @attacher.file.id
+      end
+
+      it "persists any other attribute changes" do
+        @attacher.attach_cached(fakeio)
+        @user.save
+
+        @user.name = "Janko"
+        @attacher.atomic_promote
+
+        assert_equal "Janko", @user.name
+        assert_equal "Janko", @user.reload.name
+      end
+
+      it "executes the given block before persisting" do
+        @attacher.attach_cached(fakeio)
+        @user.save
+
+        @attacher.atomic_promote { @user.name = "Janko" }
+
+        assert_equal "Janko", @user.name
+        assert_equal "Janko", @user.reload.name
+      end
+
+      it "fails on attachment change" do
+        @attacher.attach_cached(fakeio)
+        @user.save
+
+        @user.class.update_all(avatar_data: nil)
+
+        @user.name = "Janko"
+        assert_raises(Shrine::AttachmentChanged) do
+          @attacher.atomic_promote { @block_called = true }
+        end
+
+        @user.reload
+        @attacher.reload
+
+        assert_nil @attacher.file
+        assert_nil @user.name
+        refute @block_called
+      end
+
+      it "respects column serializer" do
+        @attacher = @shrine::Attacher.from_model(@user, :avatar, column_serializer: RubySerializer)
+        @attacher.attach_cached(fakeio)
+        @user.save
+
+        @attacher.atomic_promote
+
+        @user.reload
+        @attacher.reload
+        assert @attacher.stored?
+      end
+
+      it "accepts custom reload strategy" do
+        cached_file = @attacher.attach_cached(fakeio)
+        @user.save
+
+        @user.class.update_all(avatar_data: nil) # this change will not be detected
+
+        @user.name = "Janko"
+        @attacher.atomic_promote(reload: -> (&block) {
+          block.call @user.class.new(avatar_data: cached_file.to_json)
+        })
+
+        @user.reload
+        @attacher.reload
+        assert @attacher.stored?
+        assert_equal "Janko", @user.name
+      end
+
+      it "allows disabling reloading" do
+        cached_file = @attacher.attach_cached(fakeio)
+        @user.save
+
+        @user.class.update_all(avatar_data: nil) # this change will not be detected
+
+        @user.name = "Janko"
+        @attacher.atomic_promote(reload: false)
+
+        @user.reload
+        @attacher.reload
+        assert @attacher.stored?
+        assert_equal "Janko", @user.name
+      end
+
+      it "accepts custom persist strategy" do
+        @attacher.attach_cached(fakeio)
+        @user.save
+
+        @attacher.atomic_promote(persist: -> {
+          @user.name = "Janko"
+          @user.save
+        })
+
+        @user.reload
+        @attacher.reload
+        assert @attacher.stored?
+        assert_equal "Janko", @user.name
+      end
+
+      it "allows disabling persistence" do
+        @attacher.attach_cached(fakeio)
+        @user.save
+
+        @user.name = "Janko"
+        @attacher.atomic_promote(persist: false)
+
+        assert @attacher.stored?
+        assert_equal "Janko", @user.name
+
+        @user.reload
+        @attacher.reload
+        assert @attacher.cached?
+        assert_nil @user.name
+      end
+
+      it "raises NotImplementedError for non-Dynamoid attacher" do
+        @attacher = @shrine::Attacher.new
+
+        assert_raises NotImplementedError do
+          @attacher.atomic_promote
+        end
+      end
+    end
+
+    describe "#atomic_persist" do
+      it "persists the record" do
+        file = @attacher.attach(fakeio)
+        @user.save
+
+        @user.name = "Janko"
+        @attacher.atomic_persist
+
+        assert_equal "Janko", @user.name
+        assert_equal "Janko", @user.reload.name
+        assert_equal file,    @attacher.file
+      end
+
+      it "executes the given block before persisting" do
+        @attacher.attach(fakeio)
+        @user.save
+
+        @attacher.atomic_persist { @user.name = "Janko" }
+
+        assert_equal "Janko", @user.name
+        assert_equal "Janko", @user.reload.name
+      end
+
+      it "fails on attachment change" do
+        @attacher.attach(fakeio)
+        @user.save
+
+        @user.class.update_all(avatar_data: nil)
+
+        @user.name = "Janko"
+        assert_raises(Shrine::AttachmentChanged) do
+          @attacher.atomic_persist { @block_called = true }
+        end
+
+        @user.reload
+        @attacher.reload
+
+        assert_nil @attacher.file
+        assert_nil @user.name
+        refute @block_called
+      end
+
+      it "respects column serializer" do
+        @attacher = @shrine::Attacher.from_model(@user, :avatar, column_serializer: RubySerializer)
+        @attacher.attach(fakeio)
+        @user.save
+
+        @user.name = "Janko"
+        @attacher.atomic_persist
+
+        @user.reload
+        @attacher.reload
+        assert_equal "Janko", @user.name
+      end
+
+      it "accepts custom reload strategy" do
+        @attacher.attach(fakeio)
+        @user.save
+
+        @user.class.update_all(avatar_data: nil) # this change will not be detected
+
+        @user.name = "Name"
+        @attacher.atomic_persist(reload: -> (&block) { block.call(@user) })
+
+        assert_equal "Name", @user.reload.name
+      end
+
+      it "allows disabling reloading" do
+        @attacher.attach(fakeio)
+        @user.save
+
+        @user.class.update_all(avatar_data: nil) # this change will not be detected
+
+        @user.name = "Name"
+        @attacher.atomic_persist(reload: false)
+
+        assert_equal "Name", @user.reload.name
+      end
+
+      it "accepts custom persist strategy" do
+        @attacher.attach(fakeio)
+        @user.save
+
+        @attacher.atomic_persist(persist: -> {
+          @user.name = "Janko"
+          @user.save
+        })
+
+        assert_equal "Janko", @user.name
+        assert_equal "Janko", @user.reload.name
+      end
+
+      it "allows disabling persistence" do
+        @attacher.attach(fakeio)
+        @user.save
+
+        @user.name = "Janko"
+        @attacher.atomic_persist(persist: false)
+
+        assert_equal "Janko", @user.name
+        assert_nil @user.reload.name
+      end
+
+      it "accepts current file" do
+        @user.save
+
+        file = @attacher.upload(fakeio)
+        @user.class.update_all(avatar_data: file.to_json)
+
+        assert_raises(Shrine::AttachmentChanged) do
+          @attacher.atomic_persist
+        end
+
+        @user.name = "Janko"
+        @attacher.atomic_persist(file)
+
+        assert_equal "Janko", @user.name
+        assert_equal "Janko", @user.reload.name
+      end
+
+      it "raises NotImplementedError for non-Dynamoid attacher" do
+        @attacher = @shrine::Attacher.new
+
+        assert_raises NotImplementedError do
+          @attacher.atomic_persist
+        end
+      end
+    end
+
+    describe "#persist" do
+      it "persists the record" do
+        file = @attacher.upload(fakeio)
+        @user.avatar_data = file.to_json
+
+        @attacher.persist
+
+        assert_equal file.to_json, @user.reload.avatar_data
+      end
+
+      it "persists only changes" do
+        @user.save
+        @user.class.update_all(name: "Janko")
+        @user.reload
+
+        file = @attacher.upload(fakeio)
+        @user.avatar_data = file.to_json
+
+        @attacher.persist
+
+        assert_equal "Janko", @user.reload.name
+      end
+
+      it "skips validations" do
+        @user.instance_eval do
+          def validate
+            errors.add(:name, "must be present")
+          end
+        end
+
+        @user.name = "Janko"
+        @user.save(validate: false)
+
+        @user.name = nil
+        @attacher.persist
+
+        assert_nil @user.reload.name
+      end
+
+      it "triggers callbacks when persisting" do
+        @user.save
+
+        after_save_called = false
+        @user.class.after_save { after_save_called = true }
+
+        @user.name = "Janko"
+        @attacher.persist
+
+        assert after_save_called
+      end
+
+      it "raises NotImplementedError for non-Dynamoid attacher" do
+        @attacher = @shrine::Attacher.new
+
+        assert_raises NotImplementedError do
+          @attacher.persist
+        end
+      end
+    end
+  end
+end

--- a/test/lib/dynamoid/config_loader.rb
+++ b/test/lib/dynamoid/config_loader.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Dynamoid
+  module ConfigLoader
+    class << self
+      def load!(path, environment)
+        template = ERB.new(File.new(path).read)
+        yaml = YAML.load(template.result).deep_symbolize_keys
+        ddb_config = yaml[environment]
+
+        ::Dynamoid.configure do |config|
+          config.reset
+
+          config.logger = nil
+          config.namespace = "shrine_development"
+          config.endpoint = ddb_config[:host]
+        end
+      end
+    end
+  end
+end

--- a/test/lib/dynamoid/reset.rb
+++ b/test/lib/dynamoid/reset.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Dynamoid
+  module Reset
+    class << self
+      def all
+        Dynamoid.adapter.list_tables.each do |table|
+          # Only delete tables in our namespace
+          if table =~ /^#{Dynamoid::Config.namespace}/
+            Dynamoid.adapter.delete_table(table)
+          end
+        end
+
+        Dynamoid.adapter.tables.clear
+        # Recreate all tables to avoid unexpected errors
+        Dynamoid.included_models.each { |m| m.create_table(sync: true) }
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,35 @@
+require "bundler/setup"
+
+require "minitest/autorun"
+require "minitest/pride"
+require "minitest/spec"
+require "mocha/minitest"
+
+require "shrine"
+require "shrine/storage/memory"
+require "dynamoid"
+
+require "stringio"
+
+require_relative "lib/dynamoid/config_loader"
+require_relative "lib/dynamoid/reset"
+
+require "minitest/byebug" if ENV["DEBUG"]
+
+Dynamoid::ConfigLoader.load!("test/dynamoid.yml", :test)
+
+class Minitest::Test
+  def fakeio(content = "file")
+    StringIO.new(content)
+  end
+end
+
+class RubySerializer
+  def self.dump(data)
+    data.to_s
+  end
+
+  def self.load(data)
+    eval(data)
+  end
+end


### PR DESCRIPTION
Created first version as a PR in case you wanted to review it and change it.

All tests pass however I'm not quite sure about [this line](https://github.com/shrinerb/shrine-dynamoid/compare/feature/create-dynamoid?expand=1#diff-b984138343ef017d91528e82363945acR93).

I didn't dig too deep into it but I couldn't figure out a way to actually be sure that field is a Hash. 
It could be any base Ruby datatype, or at least it could be Hash or Array.

I'm going to test this version on my project and will get back to you with more information.